### PR TITLE
Add LinkCommand and enhance HelpCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -12,7 +12,40 @@ public class HelpCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
             + "Example: " + COMMAND_WORD;
 
-    public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
+    public static final String SHOWING_HELP_MESSAGE = "Opened help window.\n\n"
+            + "Available Commands:\n\n"
+            + "1. " + AddCommand.COMMAND_WORD + " - Add a person\n"
+            + "   " + AddCommand.MESSAGE_USAGE + "\n\n"
+            + "2. " + AddClassCommand.COMMAND_WORD + " - Add a tuition class\n"
+            + "   " + AddClassCommand.MESSAGE_USAGE + "\n\n"
+            + "3. " + EditCommand.COMMAND_WORD + " - Edit a person\n"
+            + "   " + EditCommand.MESSAGE_USAGE + "\n\n"
+            + "4. " + EditClassCommand.COMMAND_WORD + " - Edit a class\n"
+            + "   " + EditClassCommand.MESSAGE_USAGE + "\n\n"
+            + "5. " + DeleteCommand.COMMAND_WORD + " - Delete a person\n"
+            + "   " + DeleteCommand.MESSAGE_USAGE + "\n\n"
+            + "6. " + DeleteClassCommand.COMMAND_WORD + " - Delete a class\n"
+            + "   " + DeleteClassCommand.MESSAGE_USAGE + "\n\n"
+            + "7. " + ListCommand.COMMAND_WORD + " - List all persons\n"
+            + "   Usage: " + ListCommand.COMMAND_WORD + "\n\n"
+            + "8. " + ListChildrenCommand.COMMAND_WORD + " - List all children\n"
+            + "   Usage: " + ListChildrenCommand.COMMAND_WORD + "\n\n"
+            + "9. " + FindCommand.COMMAND_WORD + " - Find persons by keyword\n"
+            + "   " + FindCommand.MESSAGE_USAGE + "\n\n"
+            + "10. " + FilterCommand.COMMAND_WORD + " - Filter persons by criteria\n"
+            + "   " + FilterCommand.MESSAGE_USAGE + "\n\n"
+            + "11. " + JoinClassCommand.COMMAND_WORD + " - Add a person to a class\n"
+            + "   " + JoinClassCommand.MESSAGE_USAGE + "\n\n"
+            + "12. " + AttendCommand.COMMAND_WORD + " - Mark attendance\n"
+            + "   " + AttendCommand.MESSAGE_USAGE + "\n\n"
+            + "13. " + LinkCommand.COMMAND_WORD + " - Link a parent to a child\n"
+            + "   " + LinkCommand.MESSAGE_USAGE + "\n\n"
+            + "14. " + ClearCommand.COMMAND_WORD + " - Clear all entries\n"
+            + "   Usage: " + ClearCommand.COMMAND_WORD + "\n\n"
+            + "15. " + ExitCommand.COMMAND_WORD + " - Exit the program\n"
+            + "   Usage: " + ExitCommand.COMMAND_WORD + "\n\n"
+            + "16. " + COMMAND_WORD + " - Show this help message\n"
+            + "   " + MESSAGE_USAGE;
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/LinkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LinkCommand.java
@@ -1,0 +1,141 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CHILD;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PARENT;
+
+import java.util.List;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Parent;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Student;
+
+/**
+ * Links a parent and a child (student) in the address book, establishing a bidirectional relationship.
+ */
+public class LinkCommand extends Command {
+
+    public static final String COMMAND_WORD = "link";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Links a parent to a child (student). "
+            + "Parameters: "
+            + PREFIX_PARENT + "PARENT_NAME "
+            + PREFIX_CHILD + "CHILD_NAME\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_PARENT + "John Doe "
+            + PREFIX_CHILD + "Jane Doe";
+
+    public static final String MESSAGE_SUCCESS = "Successfully linked parent %s to child %s";
+    public static final String MESSAGE_PARENT_NOT_EXIST = "This parent does not exist in the address book";
+    public static final String MESSAGE_CHILD_NOT_EXIST = "This child does not exist in the address book";
+    public static final String MESSAGE_NOT_PARENT = "The person specified is not a parent";
+    public static final String MESSAGE_NOT_STUDENT = "The person specified is not a student";
+    public static final String MESSAGE_ALREADY_LINKED = "This parent and child are already linked";
+
+    private final String parentName;
+    private final String childName;
+
+    /**
+     * Creates a LinkCommand to link the specified parent to the specified child.
+     *
+     * @param parentName The name of the parent.
+     * @param childName The name of the child (student).
+     */
+    public LinkCommand(String parentName, String childName) {
+        requireNonNull(parentName);
+        requireNonNull(childName);
+        this.parentName = parentName;
+        this.childName = childName;
+    }
+
+    /**
+     * Executes the link command to establish a bidirectional relationship between a parent and child.
+     *
+     * @param model The model which the command should operate on.
+     * @return A CommandResult with the success message.
+     * @throws CommandException If the parent or child does not exist, or if they're not the correct type.
+     */
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        // Find the parent by name
+        List<Person> personList = model.getFilteredPersonList();
+        Person parentPerson = personList.stream()
+                .filter(p -> p.getName().fullName.equals(parentName))
+                .findFirst()
+                .orElse(null);
+
+        if (parentPerson == null) {
+            throw new CommandException(MESSAGE_PARENT_NOT_EXIST);
+        }
+
+        if (!(parentPerson instanceof Parent)) {
+            throw new CommandException(MESSAGE_NOT_PARENT);
+        }
+
+        // Find the child by name
+        Person childPerson = personList.stream()
+                .filter(p -> p.getName().fullName.equals(childName))
+                .findFirst()
+                .orElse(null);
+
+        if (childPerson == null) {
+            throw new CommandException(MESSAGE_CHILD_NOT_EXIST);
+        }
+
+        if (!(childPerson instanceof Student)) {
+            throw new CommandException(MESSAGE_NOT_STUDENT);
+        }
+
+        Parent parent = (Parent) parentPerson;
+        Student child = (Student) childPerson;
+
+        // Check if already linked
+        if (parent.getChildren().contains(child)) {
+            throw new CommandException(MESSAGE_ALREADY_LINKED);
+        }
+
+        // Establish bidirectional relationship
+        parent.addChild(child);
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, parentName, childName));
+    }
+
+    /**
+     * Checks if this LinkCommand is equal to another object.
+     *
+     * @param other The object to compare with.
+     * @return True if both objects are LinkCommands with the same parent and child names.
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof LinkCommand)) {
+            return false;
+        }
+
+        LinkCommand otherLinkCommand = (LinkCommand) other;
+        return parentName.equals(otherLinkCommand.parentName)
+                && childName.equals(otherLinkCommand.childName);
+    }
+
+    /**
+     * Returns a string representation of this LinkCommand.
+     *
+     * @return A string representation of this command.
+     */
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("parentName", parentName)
+                .add("childName", childName)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -22,6 +22,7 @@ import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.JoinClassCommand;
+import seedu.address.logic.commands.LinkCommand;
 import seedu.address.logic.commands.ListChildrenCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -104,6 +105,9 @@ public class AddressBookParser {
 
         case AttendCommand.COMMAND_WORD:
             return new AttendCommandParser().parse(arguments);
+
+        case LinkCommand.COMMAND_WORD:
+            return new LinkCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -17,5 +17,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_TUTOR = new Prefix("tutor/");
     public static final Prefix PREFIX_OLD_CLASS = new Prefix("o/");
     public static final Prefix PREFIX_CLASS = new Prefix("c/");
+    public static final Prefix PREFIX_PARENT = new Prefix("parent/");
+    public static final Prefix PREFIX_CHILD = new Prefix("child/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/LinkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/LinkCommandParser.java
@@ -1,0 +1,48 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_CHILD;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PARENT;
+
+import java.util.stream.Stream;
+
+import seedu.address.logic.commands.LinkCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new LinkCommand object
+ */
+public class LinkCommandParser implements Parser<LinkCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the LinkCommand
+     * and returns a LinkCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public LinkCommand parse(String args) throws ParseException {
+        String trimmed = args.trim();
+        ArgumentMultimap map = ArgumentTokenizer.tokenize(" " + trimmed, PREFIX_PARENT, PREFIX_CHILD);
+
+        if (!arePrefixesPresent(map, PREFIX_PARENT, PREFIX_CHILD) || !map.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LinkCommand.MESSAGE_USAGE));
+        }
+
+        if (!map.getValue(PREFIX_PARENT).isPresent() || !map.getValue(PREFIX_CHILD).isPresent()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, LinkCommand.MESSAGE_USAGE));
+        }
+
+        String parentName = map.getValue(PREFIX_PARENT).get();
+        String childName = map.getValue(PREFIX_CHILD).get();
+
+        return new LinkCommand(parentName, childName);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/LinkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LinkCommandTest.java
@@ -1,0 +1,155 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.util.HashSet;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Parent;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.Student;
+import seedu.address.model.person.Tutor;
+
+public class LinkCommandTest {
+
+    private Model model;
+    private Parent parent;
+    private Student student;
+    private Tutor tutor;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(new AddressBook(), new UserPrefs());
+
+        parent = new Parent(
+                new Name("John Doe"),
+                new Phone("98765432"),
+                new Email("john@example.com"),
+                new Address("10 Kent Ridge Road"),
+                new HashSet<>());
+
+        student = new Student(
+                new Name("Jane Doe"),
+                new Phone("87654321"),
+                new Email("jane@example.com"),
+                new Address("20 Kent Ridge Road"),
+                new HashSet<>());
+
+        tutor = new Tutor(
+                new Name("Mr Smith"),
+                new Phone("91234567"),
+                new Email("smith@example.com"),
+                new Address("1 Tutor Lane"),
+                new HashSet<>());
+
+        model.addPerson(parent);
+        model.addPerson(student);
+        model.addPerson(tutor);
+    }
+
+    @Test
+    public void constructor_nullParentName_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new LinkCommand(null, "Jane Doe"));
+    }
+
+    @Test
+    public void constructor_nullChildName_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new LinkCommand("John Doe", null));
+    }
+
+    @Test
+    public void execute_linkSuccess() throws Exception {
+        LinkCommand command = new LinkCommand("John Doe", "Jane Doe");
+        CommandResult result = command.execute(model);
+
+        assertEquals(String.format(LinkCommand.MESSAGE_SUCCESS, "John Doe", "Jane Doe"),
+                result.getFeedbackToUser());
+        assertTrue(parent.getChildren().contains(student));
+        assertTrue(student.getParents().contains(parent));
+    }
+
+    @Test
+    public void execute_parentNotFound_throwsCommandException() {
+        LinkCommand command = new LinkCommand("NonExistent Parent", "Jane Doe");
+        assertThrows(CommandException.class, LinkCommand.MESSAGE_PARENT_NOT_EXIST, () ->
+                command.execute(model));
+    }
+
+    @Test
+    public void execute_childNotFound_throwsCommandException() {
+        LinkCommand command = new LinkCommand("John Doe", "NonExistent Child");
+        assertThrows(CommandException.class, LinkCommand.MESSAGE_CHILD_NOT_EXIST, () ->
+                command.execute(model));
+    }
+
+    @Test
+    public void execute_notParentType_throwsCommandException() {
+        LinkCommand command = new LinkCommand("Mr Smith", "Jane Doe");
+        assertThrows(CommandException.class, LinkCommand.MESSAGE_NOT_PARENT, () ->
+                command.execute(model));
+    }
+
+    @Test
+    public void execute_notStudentType_throwsCommandException() {
+        LinkCommand command = new LinkCommand("John Doe", "Mr Smith");
+        assertThrows(CommandException.class, LinkCommand.MESSAGE_NOT_STUDENT, () ->
+                command.execute(model));
+    }
+
+    @Test
+    public void execute_alreadyLinked_throwsCommandException() throws Exception {
+        // Link parent and child first
+        new LinkCommand("John Doe", "Jane Doe").execute(model);
+
+        // Try to link again
+        LinkCommand command = new LinkCommand("John Doe", "Jane Doe");
+        assertThrows(CommandException.class, LinkCommand.MESSAGE_ALREADY_LINKED, () ->
+                command.execute(model));
+    }
+
+    @Test
+    public void equals() {
+        LinkCommand command1 = new LinkCommand("John Doe", "Jane Doe");
+        LinkCommand command2 = new LinkCommand("John Doe", "Jane Doe");
+        LinkCommand command3 = new LinkCommand("Bob Lim", "Jane Doe");
+        LinkCommand command4 = new LinkCommand("John Doe", "Alice Tan");
+
+        // same object -> returns true
+        assertTrue(command1.equals(command1));
+
+        // same values -> returns true
+        assertTrue(command1.equals(command2));
+
+        // different parent -> returns false
+        assertFalse(command1.equals(command3));
+
+        // different child -> returns false
+        assertFalse(command1.equals(command4));
+
+        // null -> returns false
+        assertFalse(command1.equals(null));
+
+        // different type -> returns false
+        assertFalse(command1.equals(1));
+    }
+
+    @Test
+    public void toString_returnsCorrectFormat() {
+        LinkCommand command = new LinkCommand("John Doe", "Jane Doe");
+        assertTrue(command.toString().contains("John Doe"));
+        assertTrue(command.toString().contains("Jane Doe"));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/LinkCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/LinkCommandParserTest.java
@@ -1,0 +1,70 @@
+package seedu.address.logic.parser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.LinkCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class LinkCommandParserTest {
+
+    private final LinkCommandParser parser = new LinkCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse("  "));
+    }
+
+    @Test
+    public void parse_validArgs_returnsLinkCommand() throws Exception {
+        LinkCommand expected = new LinkCommand("John Doe", "Jane Doe");
+        LinkCommand result = parser.parse("parent/John Doe child/Jane Doe");
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void parse_validArgsWithWhitespace_returnsLinkCommand() throws Exception {
+        LinkCommand expected = new LinkCommand("John Doe", "Jane Doe");
+        LinkCommand result = parser.parse("  parent/John Doe   child/Jane Doe  ");
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void parse_missingParentPrefix_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse("John Doe child/Jane Doe"));
+    }
+
+    @Test
+    public void parse_missingChildPrefix_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse("parent/John Doe Jane Doe"));
+    }
+
+    @Test
+    public void parse_invalidPreamble_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse("extra parent/John Doe child/Jane Doe"));
+    }
+
+    @Test
+    public void parse_missingAllPrefixes_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse("some random text"));
+    }
+
+    @Test
+    public void parse_onlyParentPrefix_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse("parent/John Doe"));
+    }
+
+    @Test
+    public void parse_onlyChildPrefix_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse("child/Jane Doe"));
+    }
+
+    @Test
+    public void parse_reversedOrder_returnsLinkCommand() throws Exception {
+        LinkCommand expected = new LinkCommand("John Doe", "Jane Doe");
+        LinkCommand result = parser.parse("child/Jane Doe parent/John Doe");
+        assertEquals(expected, result);
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `LinkCommand` for bidirectional parent-child linking
- Enhance `HelpCommand` to display all available commands
- Add comprehensive test coverage for new features

## Changes

### 1. LinkCommand Implementation
- **New command**: `link` for establishing parent-child relationships
- **Syntax**: `link parent/PARENT_NAME child/CHILD_NAME`
- **Functionality**:
  - Links a parent to a child (student) bidirectionally
  - Validates both persons exist in the address book
  - Ensures correct person types (Parent and Student)
  - Prevents duplicate links
  - Leverages existing `addChild()` method for bidirectional relationship

### 2. Enhanced HelpCommand
- Lists all 16 available commands with usage syntax
- Provides comprehensive help information when user types `help`
- Includes: add, addclass, edit, editclass, delete, deleteclass, list, children, find, filter, join, attend, link, clear, exit, help