### PR TITLE
Fix: Prevent integer overflow in Index parsing

### DIFF
--- a/src/main/java/seedu/address/commons/core/index/Index.java
+++ b/src/main/java/seedu/address/commons/core/index/Index.java
@@ -42,8 +42,12 @@ public class Index {
 
     /**
      * Creates a new {@code Index} using a one-based index.
+     * @throws IndexOutOfBoundsException if {@code oneBasedIndex} is less than 1.
      */
     public static Index fromOneBased(int oneBasedIndex) {
+        if (oneBasedIndex < 1) {
+            throw new IndexOutOfBoundsException("Index should be a positive integer");
+        }
         return new Index(oneBasedIndex - 1);
     }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -42,7 +42,12 @@ public class ParserUtil {
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
             throw new ParseException(MESSAGE_INVALID_INDEX);
         }
-        return Index.fromOneBased(Integer.parseInt(trimmedIndex));
+        int index = Integer.parseInt(trimmedIndex);
+        // Prevent integer overflow issues with extremely large indices
+        if (index > 10000) {
+            throw new ParseException(MESSAGE_INVALID_INDEX);
+        }
+        return Index.fromOneBased(index);
     }
 
     /**


### PR DESCRIPTION
## Summary
Add validation to prevent integer overflow and invalid indices in Index creation.

## Changes
- Added validation in `Index.fromOneBased()` to reject indices < 1
- Added upper bound check (10000) in `ParserUtil.parseIndex()` to prevent overflow issues
- Throw appropriate exceptions for invalid indices

## Issue
Fixes #171

## Impact
- Prevents negative zero-based indices from being created
- Prevents integer overflow with extremely large index values
- Improves application stability