### PR TITLE
Fix: Correct command prefix in AttendCommand usage message

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AttendCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AttendCommand.java
@@ -35,7 +35,7 @@ public class AttendCommand extends Command {
             + PREFIX_STATUS + "STATUS (PRESENT or ABSENT)\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
-            + PREFIX_SESSION + "MATH101 "
+            + PREFIX_CLASS + "MATH101 "
             + PREFIX_SESSION + "Session 1 "
             + PREFIX_STATUS + "PRESENT";
 


### PR DESCRIPTION
## Summary
Fix incorrect command prefix in AttendCommand usage example.

## Changes
- Changed line 38 from `PREFIX_SESSION` to `PREFIX_CLASS` for the class name parameter

## Issue
Fixes #175

## Impact
- Corrects user documentation to show proper command syntax
- Users will see the correct prefix (c/) for class name instead of sess/ 