### PR TITLE
Fix: Improve hashCode implementation in AddressBook

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -3,6 +3,7 @@ package seedu.address.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Objects;
 
 import javafx.collections.ObservableList;
 import seedu.address.model.classroom.TuitionClass;
@@ -240,6 +241,6 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     @Override
     public int hashCode() {
-        return persons.hashCode() ^ classes.hashCode();
+        return Objects.hash(persons, classes);
     }
 }


### PR DESCRIPTION
## Summary
Replace XOR-based hashCode with Objects.hash() to avoid collision issues.

## Changes
- Import java.util.Objects
- Replace `persons.hashCode() ^ classes.hashCode()` with `Objects.hash(persons, classes)`

## Issue
Fixes #174

## Impact
- Prevents hashCode collisions when lists are swapped (A^B == B^A problem)
- More robust hash function for use in HashMap/HashSet