### PR TITLE
Fix filter command documentation format

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -514,7 +514,7 @@ Action | Format, Examples
 **Edit** | `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [ro/PERSON_TYPE] [t/TAGS]​` <br> e.g., `edit 2 n/James Lee e/jameslee@example.com`
 **Edit Class** | `editclass o/OLD_CLASS_NAME c/NEW_CLASS_NAME` <br> e.g., `editclass o/Sec2-Math-A c/Sec3-Math-A`
 **Exit** | `exit`
-**Filter** | `filter ro/STUDENT\|TUTOR\|PARENT` <br> e.g., `filter ro/student`
+**Filter** | `filter ro/PERSON_TYPE` <br> e.g., `filter ro/student`
 **Find** | `find KEYWORD [MORE_KEYWORDS]` <br> e.g., `find James Jake`
 **Help** | `help`
 **Join** | `join n/NAME c/CLASS` <br> e.g., `join n/John Doe c/Sec2-Math-A`


### PR DESCRIPTION
## Summary
- Changed filter command format in command summary from `ro/STUDENT|TUTOR|PARENT` to `ro/PERSON_TYPE` to match the standard parameter declaration format used in other commands

Resolves #269