### PR TITLE
Remove filler placeholder from DG appendix

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1233,8 +1233,6 @@ testers are expected to do more *exploratory* testing.
    1. Re-launch the app by double-clicking the jar file.<br>
       Expected: The most recent window size and location is retained.
 
-1. _{ more test cases …​ }_
-
 ### Adding a person
 
 1. Adding a person with all required fields


### PR DESCRIPTION
## Summary
- Removed the empty placeholder `_{ more test cases …​ }_` from the Launch and shutdown section in the manual testing appendix

Resolves #272